### PR TITLE
Add candy guard derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,11 +392,20 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "candy-guard-derive",
  "candy-machine",
  "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
+]
+
+[[package]]
+name = "candy-guard-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-    "programs/*"
+    "programs/*",
+    "macros/*"
 ]

--- a/macros/candy-guard-derive/Cargo.toml
+++ b/macros/candy-guard-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "candy-guard-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.98", features = ["extra-traits"] }
+quote = "1.0.20"

--- a/macros/candy-guard-derive/src/lib.rs
+++ b/macros/candy-guard-derive/src/lib.rs
@@ -1,0 +1,118 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(CandyGuard)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(syn::FieldsNamed { ref named, .. }),
+        ..
+    }) = ast.data
+    {
+        named
+    } else {
+        unimplemented!();
+    };
+
+    let unwrap_option_t = |ty: &syn::Type| -> syn::Type {
+        if let syn::Type::Path(ref p) = ty {
+            if let syn::PathArguments::AngleBracketed(ref inner_ty) = p.path.segments[0].arguments {
+                if inner_ty.args.len() != 1 {
+                    panic!("Option type was not Option<T>");
+                } else if let syn::GenericArgument::Type(ref ty) = inner_ty.args.first().unwrap() {
+                    ty.clone()
+                } else {
+                    panic!("Option type was not Option<T>");
+                }
+            } else {
+                panic!("Option type was not Option<T>");
+            }
+        } else {
+            panic!("Type was not Option<T>");
+        }
+    };
+
+    let from_data = fields.iter().map(|f| {
+        let name = &f.ident;
+        let ty = unwrap_option_t(&f.ty);
+        quote! {
+            current += #ty::size();
+            let #name = #ty::load(features, data, current)?;
+        }
+    });
+
+    let to_data = fields.iter().map(|f| {
+        let name = &f.ident;
+        let ty = unwrap_option_t(&f.ty);
+        quote! {
+            offset += #ty::size();
+            if let Some(#name) = &self.#name {
+                if offset <= data.len() {
+                    #name.save(data, offset - #ty::size())?;
+                    features = #ty::enable(features);
+                }
+            }
+        }
+    });
+
+    let struct_fields = fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! { #name }
+    });
+
+    let enabled = fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! {
+            if let Some(#name) = &self.#name {
+                conditions.push(#name);
+            }
+        }
+    });
+
+    let struct_length = fields.iter().map(|f| {
+        let ty = unwrap_option_t(&f.ty);
+        quote! { length += #ty::size(); }
+    });
+
+    let expanded = quote! {
+        impl #name {
+            pub fn from_data(features: u64, data: &mut std::cell::RefMut<&mut [u8]>) -> anchor_lang::Result<Self> {
+                let mut current = DATA_OFFSET;
+
+                #(#from_data)*
+
+                Ok(Self {
+                    #(#struct_fields,)*
+                })
+            }
+
+            pub fn to_data(&self, data: &mut [u8]) -> anchor_lang::Result<u64> {
+                let mut features = 0;
+                let mut offset = 0;
+
+                #(#to_data)*
+
+                Ok(features)
+            }
+
+            pub fn enabled_conditions(&self) -> Vec<&dyn Condition> {
+                // list of condition trait objects
+                let mut conditions: Vec<&dyn Condition> = vec![];
+                #(#enabled)*
+
+                conditions
+            }
+
+            pub fn data_length() -> usize {
+                let mut length = DATA_OFFSET;
+                #(#struct_length)*
+                length
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/programs/candy-guard/Cargo.toml
+++ b/programs/candy-guard/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 [dependencies]
 anchor-lang = "0.25.0"
 anchor-spl = "0.25.0"
+candy-guard-derive = { path = "../../macros/candy-guard-derive" }
 candy-machine = { path = "../candy-machine", features = ["cpi"] }
 mpl-token-metadata = { version = "1.2.5", features = ["no-entrypoint"] }
 solana-program = "1.9.13"

--- a/programs/candy-guard/src/guards/lamports_charge.rs
+++ b/programs/candy-guard/src/guards/lamports_charge.rs
@@ -33,7 +33,7 @@ impl Condition for LamportsCharge {
                 "Require {} lamports, accounts has {} lamports",
                 evaluation_context.amount,
                 ctx.accounts.payer.lamports(),
-            );    
+            );
             return err!(CandyGuardError::NotEnoughSOL);
         }
 

--- a/programs/candy-guard/src/instructions/update.rs
+++ b/programs/candy-guard/src/instructions/update.rs
@@ -1,76 +1,20 @@
 use anchor_lang::prelude::*;
 
-use crate::guards::*;
-use crate::state::{CandyGuard, CandyGuardData, DATA_OFFSET};
+use crate::state::{CandyGuard, CandyGuardData};
 
 pub fn update(ctx: Context<Update>, data: CandyGuardData) -> Result<()> {
     let info = ctx.accounts.candy_guard.to_account_info();
-    // current features value
-    let mut features = ctx.accounts.candy_guard.features;
-    // limit to stop the update of guards
-    let length = info.data_len();
     // account data
     let mut account_data = info.data.borrow_mut();
-
-    // for each of the guards, we disable the guard (the guard will
-    // be enabled if it is present in the data parameter)
-
-    let mut offset = DATA_OFFSET + BotTax::size();
-    features = BotTax::disable(features);
-
-    if let Some(bot_tax) = data.bot_tax {
-        if offset <= length {
-            bot_tax.save(&mut account_data, offset - BotTax::size())?;
-            features = BotTax::enable(features);
-        }
-    }
-
-    offset += LiveDate::size();
-    features = LiveDate::disable(features);
-
-    if let Some(live_date) = data.live_date {
-        if offset <= length {
-            live_date.save(&mut account_data, offset - LiveDate::size())?;
-            features = LiveDate::enable(features);
-        }
-    }
-
-    offset += LamportsCharge::size();
-    features = LamportsCharge::disable(features);
-
-    if let Some(lamports_charge) = data.lamports_charge {
-        if offset <= length {
-            lamports_charge.save(&mut account_data, offset - LamportsCharge::size())?;
-            features = LamportsCharge::enable(features);
-        }
-    }
-
-    offset += SPLTokenCharge::size();
-    features = SPLTokenCharge::disable(features);
-
-    if let Some(spltoken_charge) = data.spltoken_charge {
-        if offset <= length {
-            spltoken_charge.save(&mut account_data, offset - SPLTokenCharge::size())?;
-            features = SPLTokenCharge::enable(features);
-        }
-    }
-
-    offset += Whitelist::size();
-    features = Whitelist::disable(features);
-
-    if let Some(whitelist) = data.whitelist {
-        if offset <= length {
-            whitelist.save(&mut account_data, offset - Whitelist::size())?;
-            features = Whitelist::enable(features);
-        }
-    }
-
-    ctx.accounts.candy_guard.features = features;
+    // save the guards information to the account data and stores
+    // the updated feature flag
+    ctx.accounts.candy_guard.features = data.to_data(&mut account_data)?;
 
     Ok(())
 }
 
 #[derive(Accounts)]
+#[instruction(data: CandyGuardData)]
 pub struct Update<'info> {
     #[account(mut, has_one = authority)]
     pub candy_guard: Account<'info, CandyGuard>,


### PR DESCRIPTION
Add macro to automatically generate the code required to load/save a candy guard data. This significantly improves the way new guards are implemented, reducing it to two steps:
1. Create a new guard implementing the `Guard` and `Condition` traits
2. Add the guard as an optional field to the `CandyGuardData` struct

The macro will then add the necessary code to load the guard data (during the `mint` instruction) and save the data (during the `update` instruction).