### PR TITLE
Add authority to mint instruction

### DIFF
--- a/programs/candy-guard/src/instructions/mod.rs
+++ b/programs/candy-guard/src/instructions/mod.rs
@@ -1,7 +1,11 @@
 pub use initialize::*;
 pub use mint::*;
+pub use unwrap::*;
 pub use update::*;
+pub use wrap::*;
 
 pub mod initialize;
 pub mod mint;
+pub mod unwrap;
 pub mod update;
+pub mod wrap;

--- a/programs/candy-guard/src/instructions/unwrap.rs
+++ b/programs/candy-guard/src/instructions/unwrap.rs
@@ -1,0 +1,38 @@
+use anchor_lang::prelude::*;
+use candy_machine::CandyMachine;
+
+use crate::state::CandyGuard;
+
+pub fn unwrap(ctx: Context<Unwrap>) -> Result<()> {
+    let candy_machine_program = ctx.accounts.candy_machine_program.to_account_info();
+    let candy_guard = &ctx.accounts.candy_guard;
+    // PDA is the signer of the CPI
+    let seeds = [
+        b"candy_guard".as_ref(),
+        &candy_guard.base.to_bytes(),
+        &[candy_guard.bump],
+    ];
+    let signer = [&seeds[..]];
+
+    let update_ix = candy_machine::cpi::accounts::SetAuthority {
+        candy_machine: ctx.accounts.candy_machine.to_account_info(),
+        authority: candy_guard.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new_with_signer(candy_machine_program, update_ix, &signer);
+    // candy machine update_authority CPI
+    candy_machine::cpi::set_authority(cpi_ctx, ctx.accounts.authority.key())?;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct Unwrap<'info> {
+    #[account(has_one = authority)]
+    pub candy_guard: Account<'info, CandyGuard>,
+    #[account(mut, constraint = candy_guard.key() == candy_machine.authority)]
+    pub candy_machine: Account<'info, CandyMachine>,
+    /// CHECK: account constraints checked in account trait
+    #[account(address = candy_machine::id())]
+    pub candy_machine_program: AccountInfo<'info>,
+    pub authority: Signer<'info>,
+}

--- a/programs/candy-guard/src/instructions/update.rs
+++ b/programs/candy-guard/src/instructions/update.rs
@@ -16,7 +16,12 @@ pub fn update(ctx: Context<Update>, data: CandyGuardData) -> Result<()> {
 #[derive(Accounts)]
 #[instruction(data: CandyGuardData)]
 pub struct Update<'info> {
-    #[account(mut, has_one = authority)]
+    #[account(
+        mut,
+        has_one = authority,
+        seeds = [b"candy_guard", candy_guard.base.key().as_ref()],
+        bump = candy_guard.bump
+    )]
     pub candy_guard: Account<'info, CandyGuard>,
     pub authority: Signer<'info>,
 }

--- a/programs/candy-guard/src/instructions/wrap.rs
+++ b/programs/candy-guard/src/instructions/wrap.rs
@@ -1,0 +1,29 @@
+use anchor_lang::prelude::*;
+use candy_machine::CandyMachine;
+
+use crate::state::CandyGuard;
+
+pub fn wrap(ctx: Context<Wrap>) -> Result<()> {
+    let candy_machine_program = ctx.accounts.candy_machine_program.to_account_info();
+    let update_ix = candy_machine::cpi::accounts::SetAuthority {
+        candy_machine: ctx.accounts.candy_machine.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
+    };
+    let cpi_ctx = CpiContext::new(candy_machine_program, update_ix);
+    // candy machine update_authority CPI
+    candy_machine::cpi::set_authority(cpi_ctx, ctx.accounts.candy_guard.key())?;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct Wrap<'info> {
+    #[account(has_one = authority)]
+    pub candy_guard: Account<'info, CandyGuard>,
+    #[account(mut, has_one = authority)]
+    pub candy_machine: Account<'info, CandyMachine>,
+    /// CHECK: account constraints checked in account trait
+    #[account(address = candy_machine::id())]
+    pub candy_machine_program: AccountInfo<'info>,
+    pub authority: Signer<'info>,
+}

--- a/programs/candy-guard/src/lib.rs
+++ b/programs/candy-guard/src/lib.rs
@@ -15,10 +15,12 @@ declare_id!("FEf9mMa22GxyxVKjXDUwdiYtH8isuhAsSqBSjQg9CTzu");
 pub mod candy_guard {
     use super::*;
 
+    /// Create a new `CandyGuard` account.
     pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
         instructions::initialize(ctx)
     }
 
+    /// Mint an NFT from a `CandyMachine` "behind" a `CandyGuard`.
     pub fn mint<'info>(
         ctx: Context<'_, '_, '_, 'info, Mint<'info>>,
         creator_bump: u8,
@@ -26,7 +28,20 @@ pub mod candy_guard {
         instructions::mint(ctx, creator_bump)
     }
 
+    /// Remove a `CandyGuard` from a `CandyMachine`, setting the authority to the
+    /// `CandyGuard` authority.
+    pub fn unwrap(ctx: Context<Unwrap>) -> Result<()> {
+        instructions::unwrap(ctx)
+    }
+
+    /// Update the `CandyGuard` configuration.
     pub fn update(ctx: Context<Update>, data: CandyGuardData) -> Result<()> {
         instructions::update(ctx, data)
+    }
+
+    /// Add a `CandyGuard` to a `CandyMachine`. After the guard is added, mint
+    /// is only allowed through the `CandyGuard`.
+    pub fn wrap(ctx: Context<Wrap>) -> Result<()> {
+        instructions::wrap(ctx)
     }
 }

--- a/programs/candy-guard/src/state/candy_guard.rs
+++ b/programs/candy-guard/src/state/candy_guard.rs
@@ -6,14 +6,20 @@ use candy_guard_derive::CandyGuard;
 
 // Bytes offset for the start of the data section:
 //     8 (discriminator)
+//  + 32 (base)
+//  +  1 (bump)
 //  + 32 (authority)
 //  +  8 (u64)
-pub const DATA_OFFSET: usize = 8 + 32 + 8;
+pub const DATA_OFFSET: usize = 8 + 32 + 1 + 32 + 8;
 
 #[account]
 #[derive(Default)]
 pub struct CandyGuard {
-    // Owner of the guard
+    // Base key used to generate the PDA
+    pub base: Pubkey,
+    // Bump seed
+    pub bump: u8,
+    // Authority of the guard
     pub authority: Pubkey,
     // Guard features flag (up to 64)
     pub features: u64,

--- a/programs/candy-machine/src/instructions/mint.rs
+++ b/programs/candy-machine/src/instructions/mint.rs
@@ -26,7 +26,7 @@ pub fn mint<'info>(ctx: Context<'_, '_, '_, 'info, Mint<'info>>, creator_bump: u
 
     // the candy machine authority has "super-powers", so no need to validate instructions
     if !cmp_pubkeys(
-        &ctx.accounts.mint_authority.key(),
+        &ctx.accounts.authority.key(),
         &ctx.accounts.candy_machine.authority,
     ) {
         let instruction_sysvar_account = &ctx.accounts.instruction_sysvar_account;
@@ -291,11 +291,14 @@ pub fn get_config_line(
 #[derive(Accounts)]
 #[instruction(creator_bump: u8)]
 pub struct Mint<'info> {
-    #[account(mut)]
+    #[account(mut, has_one = authority)]
     candy_machine: Box<Account<'info, CandyMachine>>,
     /// CHECK: account constraints checked in account trait
     #[account(seeds=[PREFIX.as_bytes(), candy_machine.key().as_ref()], bump=creator_bump)]
     candy_machine_creator: UncheckedAccount<'info>,
+    // candy machine authority
+    #[account(mut)]
+    authority: Signer<'info>,
     #[account(mut)]
     payer: Signer<'info>,
     // With the following accounts we aren't using anchor macros because they are CPI'd

--- a/programs/candy-machine/src/instructions/mod.rs
+++ b/programs/candy-machine/src/instructions/mod.rs
@@ -1,7 +1,9 @@
 pub use add_config_lines::*;
 pub use initialize::*;
 pub use mint::*;
+pub use set_authority::*;
 
 pub mod add_config_lines;
 pub mod initialize;
 pub mod mint;
+pub mod set_authority;

--- a/programs/candy-machine/src/instructions/set_authority.rs
+++ b/programs/candy-machine/src/instructions/set_authority.rs
@@ -1,0 +1,17 @@
+use anchor_lang::prelude::*;
+
+use crate::CandyMachine;
+
+pub fn set_authority(ctx: Context<SetAuthority>, new_authority: Pubkey) -> Result<()> {
+    let candy_machine = &mut ctx.accounts.candy_machine;
+    candy_machine.authority = new_authority;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct SetAuthority<'info> {
+    #[account(mut, has_one = authority)]
+    candy_machine: Account<'info, CandyMachine>,
+    authority: Signer<'info>,
+}

--- a/programs/candy-machine/src/lib.rs
+++ b/programs/candy-machine/src/lib.rs
@@ -38,4 +38,8 @@ pub mod candy_machine {
     ) -> Result<()> {
         instructions::mint(ctx, creator_bump)
     }
+
+    pub fn set_authority(ctx: Context<SetAuthority>, new_authority: Pubkey) -> Result<()> {
+        instructions::set_authority(ctx, new_authority)
+    }
 }

--- a/tests/candy-machine.ts
+++ b/tests/candy-machine.ts
@@ -135,7 +135,6 @@ describe("Candy Machine", () => {
     });
 
     it("mint", async () => {
-        let candyMachine = await program.account.candyMachine.fetch(keypair.publicKey);
         // mint address
         const mint = anchor.web3.Keypair.generate();
         // creator PDA
@@ -173,6 +172,7 @@ describe("Candy Machine", () => {
             .accounts({
                 candyMachine: keypair.publicKey,
                 candyMachineCreator: candyMachineCreator,
+                authority: payer.publicKey,
                 payer: payer.publicKey,
                 metadata: metadataAddress,
                 mint: mint.publicKey,


### PR DESCRIPTION
PR adding a restriction to only allow the authority of the candy machine to mint. There are two scenarios of how a mint can happen:
1. Minting directly from a candy machine without a guard using the `authority` of the candy machine.
2. Minting through candy guard – the candy guard must be the authority of the candy machine, which can be set/unset using the `wrap` and `unwrap` instructions.