### PR TITLE
Add option to execute actions after the mint

### DIFF
--- a/programs/candy-guard/src/guards/bot_tax.rs
+++ b/programs/candy-guard/src/guards/bot_tax.rs
@@ -29,11 +29,22 @@ impl Condition for BotTax {
         Ok(())
     }
 
-    fn actions<'info>(
+    fn pre_actions<'info>(
         &self,
         _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         _candy_guard_data: &CandyGuardData,
-        _evaluation_context: &EvaluationContext,
+        _evaluation_context: &mut EvaluationContext,
+    ) -> Result<()> {
+        // the purpuse of this guard is to indicate whether the bot tax is enbled or not
+        // and to store the lamports fee
+        Ok(())
+    }
+
+    fn post_actions<'info>(
+        &self,
+        _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        _candy_guard_data: &CandyGuardData,
+        _evaluation_context: &mut EvaluationContext,
     ) -> Result<()> {
         // the purpuse of this guard is to indicate whether the bot tax is enbled or not
         // and to store the lamports fee
@@ -56,11 +67,13 @@ impl BotTax {
             error.to_string(),
             self.lamports
         );
+
         let final_fee = self.lamports.min(bot_account.lamports());
         invoke(
             &system_instruction::transfer(bot_account.key, payment_account.key, final_fee),
             &[bot_account, payment_account, system_program],
         )?;
+
         Ok(())
     }
 }

--- a/programs/candy-guard/src/guards/lamports_charge.rs
+++ b/programs/candy-guard/src/guards/lamports_charge.rs
@@ -40,11 +40,11 @@ impl Condition for LamportsCharge {
         Ok(())
     }
 
-    fn actions<'info>(
+    fn pre_actions<'info>(
         &self,
         ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         _candy_guard_data: &CandyGuardData,
-        evaluation_context: &EvaluationContext,
+        evaluation_context: &mut EvaluationContext,
     ) -> Result<()> {
         // sanity check: other guards might have updated the price on the
         // evaluation context. While it would be usually to decrease the
@@ -71,6 +71,16 @@ impl Condition for LamportsCharge {
             ],
         )?;
 
+        Ok(())
+    }
+
+    fn post_actions<'info>(
+        &self,
+        _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        _candy_guard_data: &CandyGuardData,
+        _evaluation_context: &mut EvaluationContext,
+    ) -> Result<()> {
+        // no post actions needed
         Ok(())
     }
 }

--- a/programs/candy-guard/src/guards/live_date.rs
+++ b/programs/candy-guard/src/guards/live_date.rs
@@ -54,13 +54,23 @@ impl Condition for LiveDate {
         Ok(())
     }
 
-    fn actions<'info>(
+    fn pre_actions<'info>(
         &self,
         _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         _candy_guard_data: &CandyGuardData,
-        _evaluation_context: &EvaluationContext,
+        _evaluation_context: &mut EvaluationContext,
     ) -> Result<()> {
         // no actions required
+        Ok(())
+    }
+
+    fn post_actions<'info>(
+        &self,
+        _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        _candy_guard_data: &CandyGuardData,
+        _evaluation_context: &mut EvaluationContext,
+    ) -> Result<()> {
+        // no post actions needed
         Ok(())
     }
 }

--- a/programs/candy-guard/src/guards/mod.rs
+++ b/programs/candy-guard/src/guards/mod.rs
@@ -34,13 +34,26 @@ pub trait Condition {
         evaluation_context: &mut EvaluationContext,
     ) -> Result<()>;
 
-    /// Perform the action associated with the guard. This function only
-    /// gets called when all guards have been successfuly validated.
-    fn actions<'info>(
+    /// Perform the action associated with the guard before the CPI `mint` instruction.
+    /// 
+    /// This function only gets called when all guards have been successfuly validated.
+    /// Any error generated will make the transaction to fail.
+    fn pre_actions<'info>(
         &self,
         ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         candy_guard_data: &CandyGuardData,
-        evaluation_context: &EvaluationContext,
+        evaluation_context: &mut EvaluationContext,
+    ) -> Result<()>;
+
+    /// Perform the action associated with the guard after the CPI `mint` instruction.
+    /// 
+    /// This function only gets called when all guards have been successfuly validated.
+    /// Any error generated will make the transaction to fail.
+    fn post_actions<'info>(
+        &self,
+        ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        candy_guard_data: &CandyGuardData,
+        evaluation_context: &mut EvaluationContext,
     ) -> Result<()>;
 }
 

--- a/programs/candy-guard/src/guards/spltoken_charge.rs
+++ b/programs/candy-guard/src/guards/spltoken_charge.rs
@@ -48,11 +48,11 @@ impl Condition for SPLTokenCharge {
         Ok(())
     }
 
-    fn actions<'info>(
+    fn pre_actions<'info>(
         &self,
         ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         _candy_guard_data: &CandyGuardData,
-        evaluation_context: &EvaluationContext,
+        evaluation_context: &mut EvaluationContext,
     ) -> Result<()> {
         let index = evaluation_context.spltoken_index;
         // the accounts have already been validated
@@ -68,6 +68,16 @@ impl Condition for SPLTokenCharge {
             amount: evaluation_context.amount,
         })?;
 
+        Ok(())
+    }
+
+    fn post_actions<'info>(
+        &self,
+        _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        _candy_guard_data: &CandyGuardData,
+        _evaluation_context: &mut EvaluationContext,
+    ) -> Result<()> {
+        // no post actions needed
         Ok(())
     }
 }

--- a/programs/candy-guard/src/guards/whitelist.rs
+++ b/programs/candy-guard/src/guards/whitelist.rs
@@ -116,11 +116,11 @@ impl Condition for Whitelist {
         Ok(())
     }
 
-    fn actions<'info>(
+    fn pre_actions<'info>(
         &self,
         ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
         _candy_guard_data: &CandyGuardData,
-        evaluation_context: &EvaluationContext,
+        evaluation_context: &mut EvaluationContext,
     ) -> Result<()> {
         if evaluation_context.whitelist && self.mode == WhitelistTokenMode::BurnEveryTime {
             let index = evaluation_context.whitelist_index;
@@ -137,6 +137,16 @@ impl Condition for Whitelist {
                 token_program: ctx.accounts.token_program.to_account_info(),
             })?;
         }
+        Ok(())
+    }
+
+    fn post_actions<'info>(
+        &self,
+        _ctx: &Context<'_, '_, '_, 'info, Mint<'info>>,
+        _candy_guard_data: &CandyGuardData,
+        _evaluation_context: &mut EvaluationContext,
+    ) -> Result<()> {
+        // no post actions needed
         Ok(())
     }
 }


### PR DESCRIPTION
Update the guard `Condition` trait to include `post_actions` . The `mint` instruction now executes:
1. `validate`
2. `pre_actions`
3. `mint` (from Candy Machine)
4. `post_actions`