### PR TITLE
Simplify mint instruction

### DIFF
--- a/programs/candy-guard/src/guards/mod.rs
+++ b/programs/candy-guard/src/guards/mod.rs
@@ -34,7 +34,7 @@ pub trait Condition {
     ) -> Result<()>;
 
     /// Perform the action associated with the guard before the CPI `mint` instruction.
-    /// 
+    ///
     /// This function only gets called when all guards have been successfuly validated.
     /// Any error generated will make the transaction to fail.
     fn pre_actions<'info>(
@@ -45,7 +45,7 @@ pub trait Condition {
     ) -> Result<()>;
 
     /// Perform the action associated with the guard after the CPI `mint` instruction.
-    /// 
+    ///
     /// This function only gets called when all guards have been successfuly validated.
     /// Any error generated will make the transaction to fail.
     fn post_actions<'info>(

--- a/programs/candy-guard/src/guards/whitelist.rs
+++ b/programs/candy-guard/src/guards/whitelist.rs
@@ -10,7 +10,7 @@ pub struct Whitelist {
     pub mode: WhitelistTokenMode,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Clone, Debug)]
+#[derive(AnchorSerialize, AnchorDeserialize, PartialEq, Eq, Clone, Debug)]
 pub enum WhitelistTokenMode {
     BurnEveryTime,
     NeverBurn,

--- a/programs/candy-guard/src/instructions/mint.rs
+++ b/programs/candy-guard/src/instructions/mint.rs
@@ -87,7 +87,6 @@ fn cpi_mint<'info>(ctx: &Context<'_, '_, '_, 'info, Mint<'info>>, creator_bump: 
         system_program: ctx.accounts.system_program.to_account_info(),
         rent: ctx.accounts.rent.to_account_info(),
         recent_slothashes: ctx.accounts.recent_slothashes.to_account_info(),
-        instruction_sysvar_account: ctx.accounts.instruction_sysvar_account.to_account_info(),
     };
     let cpi_ctx = CpiContext::new_with_signer(candy_machine_program, mint_ix, &signer);
     // candy machine mint CPI

--- a/programs/candy-machine/src/errors.rs
+++ b/programs/candy-machine/src/errors.rs
@@ -80,4 +80,6 @@ pub enum CandyError {
     CannotIncreaseLength,
     #[msg("Cannot switch from hidden settings")]
     CannotSwitchFromHiddenSettings,
+    #[msg("Only the authority can mint")]
+    NotAuthority,
 }

--- a/programs/candy-machine/src/instructions/add_config_lines.rs
+++ b/programs/candy-machine/src/instructions/add_config_lines.rs
@@ -139,7 +139,7 @@ pub fn add_config_lines(
 }
 
 pub fn get_config_count(data: &RefMut<&mut [u8]>) -> Result<usize> {
-    return Ok(u32::from_le_bytes(*array_ref![data, HIDDEN_SECTION, 4]) as usize);
+    Ok(u32::from_le_bytes(*array_ref![data, HIDDEN_SECTION, 4]) as usize)
 }
 
 /// Add multiple config lines to the candy machine.

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -327,7 +327,6 @@ export async function mintFromCandyMachine(program: Program<CandyMachine>, base:
             systemProgram: SystemProgram.programId,
             rent: anchor.web3.SYSVAR_RENT_PUBKEY,
             recentSlothashes: anchor.web3.SYSVAR_SLOT_HASHES_PUBKEY,
-            instructionSysvarAccount: anchor.web3.SYSVAR_INSTRUCTIONS_PUBKEY
         })
         .preInstructions([anchor.web3.SystemProgram.createAccount({
             fromPubkey: payer.publicKey,


### PR DESCRIPTION
Remove the check for last instruction from the mint – this is now check by a guard.