### PR TITLE
Rename token_mint to mint

### DIFF
--- a/js/idl/candy_guard.json
+++ b/js/idl/candy_guard.json
@@ -731,7 +731,7 @@
             "type": "u64"
           },
           {
-            "name": "tokenMint",
+            "name": "mint",
             "type": "publicKey"
           },
           {

--- a/js/src/generated/types/TokenPayment.ts
+++ b/js/src/generated/types/TokenPayment.ts
@@ -10,7 +10,7 @@ import * as web3 from '@solana/web3.js';
 import * as beetSolana from '@metaplex-foundation/beet-solana';
 export type TokenPayment = {
   amount: beet.bignum;
-  tokenMint: web3.PublicKey;
+  mint: web3.PublicKey;
   destinationAta: web3.PublicKey;
 };
 
@@ -21,7 +21,7 @@ export type TokenPayment = {
 export const tokenPaymentBeet = new beet.BeetArgsStruct<TokenPayment>(
   [
     ['amount', beet.u64],
-    ['tokenMint', beetSolana.publicKey],
+    ['mint', beetSolana.publicKey],
     ['destinationAta', beetSolana.publicKey],
   ],
   'TokenPayment',

--- a/program/src/guards/token_payment.rs
+++ b/program/src/guards/token_payment.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct TokenPayment {
     pub amount: u64,
-    pub token_mint: Pubkey,
+    pub mint: Pubkey,
     pub destination_ata: Pubkey,
 }
 
@@ -46,11 +46,8 @@ impl Condition for TokenPayment {
 
         assert_keys_equal(destination_ata.key, &self.destination_ata)?;
 
-        let token_account = assert_is_ata(
-            token_account_info,
-            &ctx.accounts.payer.key(),
-            &self.token_mint,
-        )?;
+        let token_account =
+            assert_is_ata(token_account_info, &ctx.accounts.payer.key(), &self.mint)?;
 
         if token_account.amount < self.amount {
             return err!(CandyGuardError::NotEnoughTokens);


### PR DESCRIPTION
This PR renames the field `token_mint` to `mint` in the `TokenPayment` guard to be consistent to the other `Token*` guards.