### PR TITLE
chore: fix spl-token mintTo tests

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -44,7 +44,7 @@
     "@metaplex-foundation/beet": "^0.4.0",
     "@metaplex-foundation/beet-solana": "^0.3.0",
     "@metaplex-foundation/cusper": "^0.0.2",
-    "@solana/web3.js": "^1.56.2",
+    "@solana/web3.js": "^1.66.2",
     "bn.js": "^5.2.0"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "@metaplex-foundation/mpl-token-metadata": "^2.2.4",
     "@metaplex-foundation/solita": "^0.12.0",
     "@noble/hashes": "^1.1.2",
-    "@solana/spl-token": "^0.2.0",
+    "@solana/spl-token": "^0.3.6",
     "@types/bn.js": "^5.1.0",
     "@types/debug": "^4.1.7",
     "@types/tape": "^4.13.2",

--- a/js/test/guards/freeze-token-payment.test.ts
+++ b/js/test/guards/freeze-token-payment.test.ts
@@ -168,7 +168,7 @@ test('Token Payment', async (t) => {
     authority,
     tokenMint,
     minterATA.address,
-    authority.publicKey,
+    authority,
     // airdrop 10 tokens
     10,
   );
@@ -436,7 +436,7 @@ test('Token Payment (thaw)', async (t) => {
     authority,
     tokenMint,
     minterATA.address,
-    authority.publicKey,
+    authority,
     // airdrop 10 tokens
     10,
   );
@@ -710,7 +710,7 @@ test('Token Payment (unlock not allowed)', async (t) => {
     authority,
     tokenMint,
     minterATA.address,
-    authority.publicKey,
+    authority,
     // airdrop 10 tokens
     10,
   );
@@ -977,7 +977,7 @@ test('Token Payment (unlock)', async (t) => {
     authority,
     tokenMint,
     minterAta.address,
-    authority.publicKey,
+    authority,
     // airdrop 10 tokens
     10,
   );

--- a/js/test/guards/token-payment.test.ts
+++ b/js/test/guards/token-payment.test.ts
@@ -58,7 +58,7 @@ test('Token Payment', async (t) => {
     authority,
     tokenMint,
     minterATA.address,
-    authority.publicKey,
+    authority,
     // airdrop 10 tokens
     10,
   );

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -719,6 +719,15 @@
     "@solana/web3.js" "^1.32.0"
     start-server-and-test "^1.14.0"
 
+"@solana/spl-token@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.6.tgz#35473ad2ed71fe91e5754a2ac72901e1b8b26a42"
+  integrity sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    buffer "^6.0.3"
+
 "@solana/wallet-adapter-base@^0.9.2":
   version "0.9.17"
   resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.17.tgz#b388fea0ec6da40e23342068a4cfa9be65dc8f63"
@@ -730,6 +739,27 @@
   version "1.62.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.62.0.tgz#8fef9fd443217161ddc25e701f603222047bc520"
   integrity sha512-rHnqJR5ECooUp8egurP9Qi1SKI1Q3pbF2ZkaHbEmFsSjBsyEe+Qqxa5h+7ueylqApYyk0zawnxz83y4kdrlNIA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@noble/ed25519" "^1.7.0"
+    "@noble/hashes" "^1.1.2"
+    "@noble/secp256k1" "^1.6.3"
+    "@solana/buffer-layout" "^4.0.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.0.0"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    fast-stable-stringify "^1.0.0"
+    jayson "^3.4.4"
+    node-fetch "2"
+    rpc-websockets "^7.5.0"
+    superstruct "^0.14.2"
+
+"@solana/web3.js@^1.66.2":
+  version "1.66.2"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.66.2.tgz#80b43c5868b846124fe3ebac7d3943930c3fa60c"
+  integrity sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@noble/ed25519" "^1.7.0"


### PR DESCRIPTION
Updated both web3 and spl-token packages.

Then updated all `mintTo` calls to include the keypair for the authority since just passing a
`PublicKey` is not properly handled by spl-token at this point.
