### PR TITLE
Remove mint authority check on route instruction

### DIFF
--- a/program/src/instructions/route.rs
+++ b/program/src/instructions/route.rs
@@ -35,10 +35,8 @@ pub fn route<'info>(
     let candy_machine_account = if candy_machine.to_account_info().data_is_empty() {
         None
     } else {
+        // anchor verifies program ownership
         let account: Account<CandyMachine> = Account::try_from(&candy_machine.to_account_info())?;
-        // validates the mint authority
-        assert_keys_equal(&account.mint_authority, &candy_guard.key())?;
-
         Some(Box::new(account))
     };
 

--- a/program/src/instructions/wrap.rs
+++ b/program/src/instructions/wrap.rs
@@ -29,7 +29,7 @@ pub fn wrap(ctx: Context<Wrap>) -> Result<()> {
 pub struct Wrap<'info> {
     #[account(has_one = authority)]
     pub candy_guard: Account<'info, CandyGuard>,
-    // candy machine authority
+    // candy guard authority
     pub authority: Signer<'info>,
     #[account(
         mut,


### PR DESCRIPTION
This PR removes an unnecessary mint authority check on the `route` instruction. This allows the use of the instruction even when the candy guard is unwrap or closed.