### PR TITLE
Remove implicit empty candy machine test

### DIFF
--- a/program/src/instructions/mint.rs
+++ b/program/src/instructions/mint.rs
@@ -86,12 +86,6 @@ fn process_error<'info>(
 
 /// Performs a validation of the transaction before executing the guards.
 fn validate<'info>(ctx: &Context<'_, '_, '_, 'info, Mint<'info>>) -> Result<()> {
-    let candy_machine = &ctx.accounts.candy_machine;
-    // are there items to be minted?
-    if candy_machine.items_redeemed >= candy_machine.data.items_available {
-        return err!(CandyGuardError::CandyMachineEmpty);
-    }
-
     if !cmp_pubkeys(
         &ctx.accounts.collection_mint.key(),
         &ctx.accounts.candy_machine.collection_mint,


### PR DESCRIPTION
This PR removes the implicit candy machine empty test to prevent the bot tax to be activated if a transaction is executed after all items have been minted. In order to explicitly add the empty test, the `redeemed amount` guard can be used:
```
"redeemedAmount" : {
    "maximum": number,
}
```
In this case, the `maximum` should be set to be value of items available (e.g., `100` if there are `100` items in the candy machine). After `100` items are minted, the guard will prevent any further transactions to reach the candy machine and the bot tax will apply if the `bot tax` guard is enabled.