### PR TITLE
Fix future start date

### DIFF
--- a/js/test/guards/bot-tax.test.ts
+++ b/js/test/guards/bot-tax.test.ts
@@ -68,7 +68,7 @@ test('bot tax (invalid transaction)', async (t) => {
     lastInstruction: false,
   };
   data.default.startDate = {
-    date: 32503680000, /** 01/01/3000 **/
+    date: 32503680000 /** 01/01/3000 **/,
   };
 
   const { candyGuard, candyMachine } = await API.deploy(

--- a/js/test/guards/bot-tax.test.ts
+++ b/js/test/guards/bot-tax.test.ts
@@ -68,7 +68,7 @@ test('bot tax (invalid transaction)', async (t) => {
     lastInstruction: false,
   };
   data.default.startDate = {
-    date: 1671926400,
+    date: 32503680000, /** 01/01/3000 **/
   };
 
   const { candyGuard, candyMachine } = await API.deploy(

--- a/js/test/guards/start-date.test.ts
+++ b/js/test/guards/start-date.test.ts
@@ -60,7 +60,7 @@ test('start date (in the future)', async (t) => {
 
   const data = newCandyGuardData();
   data.default.startDate = {
-    date: 1671926400,
+    date: 32503680000, /** 01/01/3000 **/
   };
 
   const { candyGuard, candyMachine } = await API.deploy(

--- a/js/test/guards/start-date.test.ts
+++ b/js/test/guards/start-date.test.ts
@@ -60,7 +60,7 @@ test('start date (in the future)', async (t) => {
 
   const data = newCandyGuardData();
   data.default.startDate = {
-    date: 32503680000, /** 01/01/3000 **/
+    date: 32503680000 /** 01/01/3000 **/,
   };
 
   const { candyGuard, candyMachine } = await API.deploy(


### PR DESCRIPTION
This PR updates the future start date in the tests to a date in the far future (`01/01/3000`). Currently, they are set to `25/12/2022`, which is not in the future anymore.